### PR TITLE
feat(i18n): add UK, DE, PL translations

### DIFF
--- a/resources/lang/de/admin.php
+++ b/resources/lang/de/admin.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'seo_title' => 'SEO-Titel',
+    'seo_heading' => 'Überschrift',
+    'seo_summary' => 'Zusammenfassung',
+    'seo_content' => 'Inhalt',
+    'seo_description' => 'Meta-Beschreibung',
+];

--- a/resources/lang/pl/admin.php
+++ b/resources/lang/pl/admin.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'seo_title' => 'Tytuł SEO',
+    'seo_heading' => 'Nagłówek',
+    'seo_summary' => 'Podsumowanie',
+    'seo_content' => 'Treść',
+    'seo_description' => 'Opis meta',
+];

--- a/resources/lang/uk/admin.php
+++ b/resources/lang/uk/admin.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'seo_title' => 'SEO заголовок',
+    'seo_heading' => 'Заголовок',
+    'seo_summary' => 'Короткий опис',
+    'seo_content' => 'Контент',
+    'seo_description' => 'Мета опис',
+];

--- a/src/Traits/HasSeo.php
+++ b/src/Traits/HasSeo.php
@@ -2,6 +2,7 @@
 
 namespace SmartCms\Seo\Traits;
 
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use SmartCms\Seo\Models\Seo;
 
 /**
@@ -14,7 +15,7 @@ trait HasSeo
     /**
      * Get the SEO relationship.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphOne
+     * @return MorphOne
      */
     public function seo()
     {


### PR DESCRIPTION
## Summary
- Add Ukrainian, German, Polish translations for SEO admin labels

## Test plan
- [ ] SEO fields show translated labels in UK/DE/PL admin locale